### PR TITLE
5.5 fix mutable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bionicmaster/eloquence-mutable",
+    "name": "sofa/eloquence-mutable",
     "description": "Flexible Searchable, Mappable, Metable, Validation and more extensions for Laravel Eloquent ORM.",
     "license": "MIT",
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sofa/eloquence-mutable",
+    "name": "bionicmaster/eloquence-mutable",
     "description": "Flexible Searchable, Mappable, Metable, Validation and more extensions for Laravel Eloquent ORM.",
     "license": "MIT",
     "support": {

--- a/src/Mutable.php
+++ b/src/Mutable.php
@@ -28,6 +28,14 @@ trait Mutable
      */
     public static function bootMutable()
     {
+        if (!isset(static::$attributeMutator)) {
+            if (function_exists('app') && app()->bound('eloquence.mutator')) {
+                static::setAttributeMutator(app('eloquence.mutator'));
+            } else {
+                static::setAttributeMutator(new Mutator);
+            }
+        }
+        
         $hooks = new Hooks;
 
         foreach (['setAttribute', 'getAttribute', 'toArray'] as $method) {


### PR DESCRIPTION
This fixes PHP Error: Call to a member function mutate() on null in [...]/sofa/eloquence-mutable/src/Mutable.php on line 89 due to previously was initialized in eloquence and with extensions was not initilized anymore
Fixes 
https://github.com/jarektkaczyk/eloquence/issues/206
https://github.com/jarektkaczyk/eloquence/issues/210